### PR TITLE
Add missing colors to gruvbox-dark theme

### DIFF
--- a/static/css/colour/gruvbox-dark.css
+++ b/static/css/colour/gruvbox-dark.css
@@ -2,21 +2,28 @@
  * https://github.com/morhetz/gruvbox
  */
 :root {
+    --dark-black: #1d2021;
     --black: #282828;
+    --bright-black: #928374;
+    
+    --white: #ebdbb2;
+    --bright-white: #fbf1c7;
+    
     --red: #cc241d;
     --green: #98971a;
     --yellow: #d79921;
     --blue: #458588;
     --magenta: #b16286;
     --cyan: #689d6a;
-    --white: #ebdbb2;
-    --dark-black: #1d2021;
-    --bright-black: #928374;
+    --orange: #d65d0e;
+    --gray: #928374;
+    
     --bright-red: #fb4934;
     --bright-green: #b8bb26;
     --bright-yellow: #fabd2f;
     --bright-blue: #83a598;
     --bright-magenta: #d3869b;
     --bright-cyan: #8ec07c;
-    --bright-white: #fbf1c7;
+    --bright-orange: #fe8019;
+    --bright-gray: #a89984;
 }


### PR DESCRIPTION
I noticed that orange and gray were missing from the original gruvbox-dark theme. I plan on using orange so I figured I would send a patch. I also put black and white colors at the top of the theme so it's easier to visually compare with the original color list (https://github.com/morhetz/gruvbox-contrib/blob/master/scss/gruvbox-dark.scss).

Thanks, great theme.