### PR TITLE
Fix spacing of UL bullets on Firefox

### DIFF
--- a/static/css/typography.css
+++ b/static/css/typography.css
@@ -93,12 +93,16 @@ ol ol {
 }
 
 ul li::marker {
-    content: '∗ ';
+    content: '∗';
     color: var(--bright-bg);
 }
 
 ol li::marker {
     color: var(--bright-bg);
+}
+
+.page__body ul li, .page__aside ul li {
+    padding-left: 0.5rem;
 }
 
 /* Blockquotes */


### PR DESCRIPTION
Firefox ignores the space after the asterisk in the ul li::marker rule, this restores the space.