### PR TITLE
Fix UL marker spacing on Firefox

### DIFF
--- a/static/css/typography.css
+++ b/static/css/typography.css
@@ -93,7 +93,7 @@ ol ol {
 }
 
 ul li::marker {
-    content: '∗ ';
+    content: '∗\00A0';
     color: var(--bright-bg);
 }
 


### PR DESCRIPTION
Replaces space with nonbreaking Unicode space

This addresses issue #5 