### PR TITLE
Fix issue with .page__body outline on Firefox

### DIFF
--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -42,7 +42,7 @@
 .page__body {
     grid-area: body;
     background-color: var(--bg);
-    outline: 1rem solid var(--bg);
+    box-shadow: 0 0 0 1rem var(--bg);
 }
 
 .page__aside {


### PR DESCRIPTION
CSS outline has issues with Firefox in several situations involving child elements with negative margins. Changing to box-shadow fixes this. Tested on Chrome and Firefox.