### PR TITLE
Set pre overflow to auto and make bg !important

### DIFF
--- a/static/css/typography.css
+++ b/static/css/typography.css
@@ -124,8 +124,8 @@ blockquote::before {
 pre,
 code, 
 kbd {
-    overflow-x: scroll;
-    background: var(--dark-bg);
+    overflow-x: auto;
+    background: var(--dark-bg) !important;
     font-family: var(--font-monospace);
     color: var(--bright-bg);
 }


### PR DESCRIPTION
Fixes 2 issues:
1. In Firefox, overflow: scroll puts an ugly unscrollable scrollbar on the page. With auto it behaves as normal but the scrollbar only appears when needed.
2. When using code highlighting, the generated Hugo styles replace the pre background color, making the page look ugly (only the text has a background, not the entire pre block). Setting the background !important fixes this. This is not ideal, but the Hugo code highlighter applies the styles directly to the element, so this is the only way to override them.

Tested on Firefox and Chrome.