### PR TITLE
Add margin and padding to pre blocks

### DIFF
--- a/static/css/typography.css
+++ b/static/css/typography.css
@@ -131,7 +131,7 @@ kbd {
 }
 
 pre {
-    padding: 1.5rem 0.75rem;
+    padding: 1.5rem;
     margin: 0 0 1.5rem 0;
 }
 

--- a/static/css/typography.css
+++ b/static/css/typography.css
@@ -130,6 +130,11 @@ kbd {
     color: var(--bright-bg);
 }
 
+pre {
+    padding: 1.5rem 0.75rem;
+    margin: 0 0 1.5rem 0;
+}
+
 /* Emphasis */
 b,
 strong {


### PR DESCRIPTION
This puts one character's worth of padding inside each pre block, making the text inside easier to read. It also changes the margin to match the spacing of paragraphs, ensuring that everything is aligned "on the line" as if it is displayed in a terminal.