### PR TITLE
Add missing colors to gruvbox-light.css

### DIFF
--- a/static/css/colour/gruvbox-light.css
+++ b/static/css/colour/gruvbox-light.css
@@ -2,22 +2,29 @@
  * https://github.com/morhetz/gruvbox
  */
 :root {
+    --dark-black: #282828;
     --black: #3c3836;
+    --bright-black: #928374;
+    
+    --white: #fbf1c7;
+    --bright-white: #f9f5d7;
+
     --red: #9d0006;
     --green: #79740e;
     --yellow: #b57614;
     --blue: #076678;
     --magenta: #8f3f71;
     --cyan: #427b58;
-    --white: #fbf1c7;
-    --dark-black: #282828;
+    --orange: #af3a03;
+    --gray: #7c6f64;
+
     --dark-white: #f2e5bc;
-    --bright-black: #928374;
     --bright-red: #cc241d;
     --bright-green: #98971a;
     --bright-yellow: #d79921;
     --bright-blue: #458588;
     --bright-magenta: #b16286;
     --bright-cyan: #689d6a;
-    --bright-white: #f9f5d7;
+    --bright-orange: #d65d0e;
+    --bright-gray: #928374;
 }


### PR DESCRIPTION
Add orange and gray (plus bright variants)

Forgot to do this when I added them to gruvbox-dark!