### PR TITLE
Prevent super/subscript from affecting line height

### DIFF
--- a/static/css/typography.css
+++ b/static/css/typography.css
@@ -153,3 +153,13 @@ hr:after {
     color: var(--bright-bg);
 }
 
+/* Prevent super/sub from affecting line height */
+sup, sub {
+    vertical-align: baseline;
+    position: relative;
+    top: -0.25rem;
+    font-size: unset;
+}
+sub { 
+    top: 0.25rem; 
+}


### PR DESCRIPTION
This keeps line height static and brings in the vertical position of super/subscript slightly to prevent overlap with multiple lines. It also unsets the font size to keep characters aligned horizontally across lines. Still legible as super/subscript but now everything is aligned.