### PR TITLE
Align and format tables

### DIFF
--- a/static/css/typography.css
+++ b/static/css/typography.css
@@ -153,3 +153,22 @@ hr:after {
     color: var(--bright-bg);
 }
 
+/* Tables */
+table {
+    border-spacing: 0;
+    border: outset .75rem var(--gray);
+    margin: 0 0 1.5rem 0;
+    overflow-wrap: anywhere;
+    background: var(--gray);
+    color: var(--dark-bg);
+}
+tbody tr:nth-child(odd) {
+   background: var(--bright-gray);
+}
+th, td {
+    padding: .75rem;
+    vertical-align: top;
+}
+th {
+    text-align: inherit;
+}


### PR DESCRIPTION
Give tables an outset border and a gray background, and make the margin consistent with other elements. Tested in Chrome and Firefox with both light and dark themes. Note that this needs the patch that adds gray and bright-gray colors to gruvbox-light.css, for light theme users.

![image](https://user-images.githubusercontent.com/85877297/128268468-2274d4dd-d50e-4056-b224-ec8865fe2677.png)
