### PR TITLE
Ensure long page content doesn't overflow

### DIFF
--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -43,6 +43,7 @@
     grid-area: body;
     background-color: var(--bg);
     box-shadow: 0 0 0 1rem var(--bg);
+    overflow-wrap: break-word;
 }
 
 .page__aside {


### PR DESCRIPTION
Very long words (and long identifiers such as git hashes) that can't fit on one line currently overflow the container, especially on smaller screens. This fixes it.