### PR TITLE
Fix UL/OL margin per #11

### DIFF
--- a/static/css/typography.css
+++ b/static/css/typography.css
@@ -76,12 +76,12 @@ a:hover, a:active {
 
 /* Lists */
 ul {
-    margin: 1rem 0;
+    margin: 0 0 1.5rem 0;
     padding-left: 1.25rem;
 }
 
 ol {
-    margin: 1rem 0;
+    margin: 0 0 1.5rem 0;
     padding-left: 1.75rem;
 }
 


### PR DESCRIPTION
I was thinking this would be more complicated than it actually was. This makes UL/OL consistent with other elements. Override for nav bar is not affected.