### PR TITLE
Add "noindex" parameter

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -15,6 +15,7 @@ ignoreErrors = ["error-remote-getjson"]
 sectionPagesMenu = "main"
 
 [params]
+noindex = false
 
 [params.theme]
 palette = "gruvbox-dark"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,6 +3,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta charset="utf-8"/>
+{{ if .Site.Params.noindex }}<meta name="robots" content="noindex" /> {{ end }}
 
 <!-- FontAwesome <https://fontawesome.com/> -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css" integrity="sha512-HK5fgLBL+xu6dm/Ii3z4xhlSUyZgTT9tuc/hSrtw6uzJOvgRr2a9jyxxT1ely+B+xFAmJKVSTbpM/CuL7qxO8w==" crossorigin="anonymous" />


### PR DESCRIPTION
Allows users to set "params.noindex = true"  to stop pages from being indexed by web crawlers. 
Also added flag to examplesite.