### PR TITLE
add pink theme, convert hard-coded color names to variables

### DIFF
--- a/static/css/colour/dark-mode.css
+++ b/static/css/colour/dark-mode.css
@@ -4,4 +4,7 @@
     --bright-bg: var(--bright-black);
     --fg: var(--white);
     --bright-fg: var(--bright-white);
+    --logo-bg: var(--green);
+    --logo-hover: var(--bright-green);
+    --highlight-bg: var(--yellow);
 }

--- a/static/css/colour/light-mode.css
+++ b/static/css/colour/light-mode.css
@@ -4,4 +4,7 @@
     --bright-bg: var(--bright-black);
     --fg: var(--black);
     --bright-fg: var(--bright-black);
+    --logo-bg: var(--green);
+    --logo-hover: var(--bright-green);
+    --highlight-bg: var(--yellow);
 }

--- a/static/css/colour/pink-mode.css
+++ b/static/css/colour/pink-mode.css
@@ -1,0 +1,10 @@
+:root {
+    --bg: var(--dusty-rose);
+    --dark-bg: var(--dark-pink);
+    --bright-bg: var(--light-pink);
+    --fg: var(--really-light-pink);
+    --bright-fg: var(--aqua);
+    --logo-bg: var(--aqua);
+    --logo-hover: var(--bright-aqua);
+    --highlight-bg: var(--aqua);
+}

--- a/static/css/colour/risotto-pink.css
+++ b/static/css/colour/risotto-pink.css
@@ -1,0 +1,11 @@
+/* risotto-pink
+ * https://github.com/rio-codes/risotto-pink
+ */
+:root {
+    --dusty-rose: #cf8c83;
+    --really-light-pink: #f9e5e4;
+    --light-pink: #edaaa6;
+    --dark-pink: #c3766c;
+    --aqua: #97e4da;
+    --bright-aqua: #b6ece5;
+}

--- a/static/css/logo.css
+++ b/static/css/logo.css
@@ -11,7 +11,7 @@
 
 .page__logo-inner {
     display: block;
-    background: var(--green);
+    background: var(--logo-bg);
     padding: 0.25rem;
 }
 
@@ -22,7 +22,7 @@ a.page__logo-inner:link, a.page__logo-inner:visited {
 
 a.page__logo-inner:hover,
 a.page__logo-inner:active {
-    background: var(--bright-green);
+    background: var(--logo-hover);
 }
 
 .page__logo-inner:before {

--- a/static/css/typography.css
+++ b/static/css/typography.css
@@ -163,7 +163,7 @@ strong {
 /* Highlighting */
 ::selection,
 mark {
-    background-color: var(--yellow);
+    background-color: var(--highlight-bg);
     color: var(--bg);
 }
 


### PR DESCRIPTION
I created a pink palette and mode for risotto. I also modified logo.css and typography.css to use variables instead of hard-coded colors from the existing palettes, making it easier to add new palettes and modes in the future. Finally, I changed the existing dark and light mode files to use the original colors.