### PR TITLE
Remove Absolute URL and replace with Relative URLs for Docker compatibility

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -1,1 +1,1 @@
-<li><a href="{{ .Permalink }}">{{ .Title | markdownify }}</a></li>
+<li><a href="{{ .RelPermalink }}">{{ .Title | markdownify }}</a></li>

--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -1,6 +1,6 @@
 {{ with .Site.Params.about }}
 <div class="aside__about">
-    {{ with .logo }}<img class="about__logo" src="{{ . | absURL }}" alt="Logo">{{ end }}
+    {{ with .logo }}<img class="about__logo" src="{{ . | relURL }}" alt="Logo">{{ end }}
 <h1 class="about__title">{{ .title }}</h1>
 {{ with .description }}<p class="about__description">{{ . | markdownify }}</p>{{ end }}
 </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/academicons/1.9.1/css/academicons.min.css" integrity="sha512-b1ASx0WHgVFL5ZQhTgiPWX+68KjS38Jk87jg7pe+qC7q9YkEtFq0z7xCglv7qGIs/68d3mAp+StfC8WKC5SSAg==" crossorigin="anonymous" />
 
 <!-- risotto -->
-<link rel="stylesheet" href="{{ printf "css/colour/%s.css" .Site.Params.theme.palette | absURL }}">
-<link rel="stylesheet" href="{{ printf "css/colour/%s.css" .Site.Params.theme.mode | absURL }}">
-<link rel="stylesheet" href="{{ "css/risotto.css" | absURL }}">
-<link rel="stylesheet" href="{{ "css/custom.css" | absURL }}">
+<link rel="stylesheet" href="{{ printf "css/colour/%s.css" .Site.Params.theme.palette | relURL }}">
+<link rel="stylesheet" href="{{ printf "css/colour/%s.css" .Site.Params.theme.mode | relURL }}">
+<link rel="stylesheet" href="{{ "css/risotto.css" | relURL }}">
+<link rel="stylesheet" href="{{ "css/custom.css" | relURL }}">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,4 +1,4 @@
-<h1 class="page__logo"><a href="{{ .Site.BaseURL }}" class="page__logo-inner">{{ .Site.Title }}</a></h1>
+<h1 class="page__logo"><a href="/" class="page__logo-inner">{{ .Site.Title }}</a></h1>
 <nav class="page__nav main-nav">
     <ul>
     {{ $currentPage := . }}

--- a/layouts/post/list.html
+++ b/layouts/post/list.html
@@ -7,7 +7,7 @@
     {{ range .Pages }}
     <article class="post">
         <header class="post__header">
-            <h1><a href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h1>
+            <h1><a href="{{ .RelPermalink }}">{{ .Title | markdownify }}</a></h1>
             <p class="post__meta">
                 {{ .Params.author }},
                 <span class="date">{{ .Date.Format "2 January 2006" }}</span>


### PR DESCRIPTION
When you run a Hugo server in docker, and serve via nginx, things get a bit iffy.

Absolute URLs like `{{.Permalink}}` and `{{ . | absURL }}` cause issues when site is served to the point that blog links are served as

![image](https://user-images.githubusercontent.com/8932732/188843249-5b92a45e-10f6-4611-80db-2540bfad4ee7.png)


and base URL(s) as 

![image](https://user-images.githubusercontent.com/8932732/188843306-9a5ad9a5-ce6e-48a1-a132-32b72813e1fe.png)


which is not ideal. Replacing them with `{{.RelPermalink}}` and `{{ . | relURL }} `fixes the issue.

Further, {`{.Site.BaseURL}}` in header.html, will do the same, but replacing with "/" works, although I am less sure about this change.

----

Note that above things while they work on default on **published** sites for Hugo, they will always fail while running Hugo in a docker server unless said changes are made.


