### PR TITLE
Update config filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Otherwise, simply [download the latest release](https://github.com/joeroe/risott
 
 ## Configure
 
-To use the theme, add `theme = 'risotto'` to your site's `config.toml`, or `theme: risotto` to your `config.yaml`.
+To use the theme, add `theme = 'risotto'` to your site's `hugo.toml`, or `theme: risotto` to your `hugo.yaml`.
 
-See `exampleSite/config.toml` for the theme-specific parameters you need to add to your site's `config.toml` or `config.yaml` to configure the theme.
+See `exampleSite/config.toml` for the theme-specific parameters you need to add to your site's `hugo.toml` or `hugo.yaml` to configure the theme.
 
 ### Colour schemes
 


### PR DESCRIPTION
I noticed https://github.com/gohugoio/hugo/pull/10621 when updating risotto today, you would probably want to update this. I did not touch `exampleSite/config.toml` in case you still use that in risotto demo and simply renaming would break it somehow.

Also, I wrote a `Development` section for quick setup of development site but did not commit as I'm not sure if you want that. Anyway I'll leave it below:

```sh
# Clone repo
hugo new site test && cd test/
# New config file still conflict with theme config
# https://github.com/gohugoio/hugo/pull/10621
rm hugo.toml
git clone https://github.com/joeroe/risotto themes/risotto
# Replicate exampleSite
cp -r themes/risotto/exampleSite/* ./
cp -r themes/risotto/layouts/* layouts/
# Fix symlink path
cd content && ln -sf ../themes/risotto/README.md _index.md && cd ../
# Start server
hugo server --disableFastRender --buildDrafts
```