### PR TITLE
Enhancement: Adding target mode support to sociallinks

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -37,6 +37,8 @@ logo = "🍚"
 [[params.socialLinks]]
 icon = "fa-brands fa-github"
 title = "GitHub"
+# When using "_blank" for "target", the link will open in a new tab or window. By default, it is set to "_self".
+target = "_blank"
 url = "https://github.com/joeroe/risotto"
 
 [[params.socialLinks]]

--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -10,7 +10,7 @@
 <ul class="aside__social-links">
     {{ range $item := .Site.Params.socialLinks }}
     <li>
-        <a href="{{ $item.url }}" rel="me" aria-label="{{ $item.title }}" title="{{ $item.title }}"><i class="{{ $item.icon }}" aria-hidden="true"></i></a>&nbsp;
+        <a href="{{ $item.url }}" target="{{ $item.target | default "_self" }}" rel="me" aria-label="{{ $item.title }}" title="{{ $item.title }}"><i class="{{ $item.icon }}" aria-hidden="true"></i></a>&nbsp;
     </li>
     {{ end }}
 </ul>


### PR DESCRIPTION
Hey there,

Thank you for this awesome theme. I really appreciate the beauty and simplicity of it. ❤️ 

I made a minor change to the "layouts/partials/about.html" file, I added an option to specify the “target” attribute in the Hugo configuration file for social links. By default, the behavior remains as "_self" This means that if users don’t explicitly set a target, it will function just as before.

Thank you for considering this PR!