### PR TITLE
Add a configuration key to enable multilingual support in the theme. Make it opt-in by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ The following files will be detected and included in your site's `<head>` sectio
 You can generate these from an image or emoji using [favicon.io](https://favicon.io/) or a similar service.
 They must be placed directly under your site's `static/` directory, i.e. not in in a subdirectory or `themes/risotto/static/`.
 
+## Multilingual Support
+
+You can enable automatic multilingual support for this theme through the key `theme.enableMultilingual`.
+
 ## Acknowledgements
 
 The 'cooked rice' emoji used as a favicon for the example site was created by the [Twemoji project](https://twemoji.twitter.com/) and is licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).

--- a/layouts/partials/lang.html
+++ b/layouts/partials/lang.html
@@ -1,3 +1,4 @@
+{{ if .Site.Params.theme.enableMultilingual }}
 <p>
     {{ $siteLanguages := .Site.Languages }}
     {{ $pageLang := .Page.Lang }}
@@ -26,3 +27,4 @@
     {{ end }}
 </p>
 <br /><br />
+{{ end }}


### PR DESCRIPTION
Hello :wave:

Thanks a lot for the great theme!

I am very new to hugo (just started this evening), and I appreciate your theme for its simplicity and overall aesthetic.

While getting started with your theme, I was a bit puzzled by the `$ echo $LANG` label that was being displayed though, and noticed from #44 that you were actually not using multilingual, so probably not seeing this.

Again, being new to Hugo, I didn't find an easy and straightforward way to just get rid of multilingual, so I thought it could be interesting to just make that feature of the theme opt-in and hide it behind a configuration key, what do you think? Also that bit of code adds unnecessary `br` tags to the page.

In order to test this Pull Request, I checked that the multilingual selection thingy is not displayed when the key is not set or is `false`. When it is `true` though, it is displayed as it would be without the PR.

Let me know what you think, happy to rework this PR in any direction you'd recommend. Feel free to close it if that is not desirable.

Thanks again for the great work! :heart:
