### PR TITLE
add header for RSS

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -22,3 +22,8 @@
 {{ if os.FileExists "static/favicon-16x16.png" }}<link rel="icon" type="image/png" sizes="16x16" href="{{ "favicon-16x16.png" | absURL }}">{{ end }}
 {{ if os.FileExists "static/apple-touch-icon.png" }}<link rel="apple-touch-icon" href="{{ "apple-touch-icon.png" | absURL }}">{{ end }}
 {{ if os.FileExists "static/site.webmanifest" }}<link rel="manifest" href="{{ "site.webmanifest" | absURL }}">{{ end }}
+
+<!-- RSS header-->
+{{ with .OutputFormats.Get "rss" -}}
+  {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
+{{ end }}


### PR DESCRIPTION
this code snippet tells web browsers that there is an RSS feed available at the specified URL, which contains content related to the current webpage. RSS feed readers can then be used to subscribe to this feed and receive updates whenever new content is published on the website.
