### PR TITLE
added OG meta tags in header

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -33,11 +33,9 @@
 <meta property="og:url" content="{{ .Page.Permalink }}" />
 {{ if isset .Params "description" }}
   <meta property="og:description" content="{{ with .Params.description }}{{ . }} &ndash; {{end}}"/> 
-  <meta name="description" content="{{ with .Params.description }}{{ . }} &ndash; {{end}}" /> 
 {{ else }}
   {{ with .Site.Params.about }}
     <meta property="og:description" content="{{ .description }}"/> 
-    <meta name="description" content="{{ .description }}" /> 
   {{ end }}
 {{ end }}
 {{ with .Site.LanguageCode}}<meta property="og:locale" content="{{ . }}" />{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -27,3 +27,18 @@
 {{ with .OutputFormats.Get "rss" -}}
   {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
 {{ end }}
+
+<!-- OG meta properties -->
+<meta property="og:title" content="{{ with .Title }}{{ . }} &ndash; {{end}}{{ .Site.Title }}" />
+<meta property="og:url" content="{{ .Page.Permalink }}" />
+{{ if isset .Params "description" }}
+  <meta property="og:description" content="{{ with .Params.description }}{{ . }} &ndash; {{end}}"/> 
+  <meta name="description" content="{{ with .Params.description }}{{ . }} &ndash; {{end}}" /> 
+{{ else }}
+  {{ with .Site.Params.about }}
+    <meta property="og:description" content="{{ .description }}"/> 
+    <meta name="description" content="{{ .description }}" /> 
+  {{ end }}
+{{ end }}
+{{ with .Site.LanguageCode}}<meta property="og:locale" content="{{ . }}" />{{ end }}
+{{ with .Site.Params.about }}<meta property="og:image" content="{{ with .logo_image }}{{ . | absURL }}{{ end }}" />{{ end }}


### PR DESCRIPTION
I added this feature in my blog using risotto theme and i figure that would be a great addition to the theme itself.

This tags are responsible for decorate the link when you share a link with someone in, for example, Whatsapp, Telegram, etc.
https://ogp.me/

<img width="444" alt="Screenshot at May 05 10-32-18" src="https://github.com/joeroe/risotto/assets/29266005/12c2748e-d5d8-4403-bd77-f9d0cd7a7090">

<img width="301" alt="image" src="https://github.com/joeroe/risotto/assets/29266005/b3394d0b-6196-451c-8b27-de2086a9bf1f">
