### PR TITLE
Add multilingual check to optionally display language selection. Fixe…

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,3 +1,5 @@
-{{- partial "lang.html" . -}}
+{{ if hugo.IsMultilingual }}
+    {{- partial "lang.html" . -}}
+{{ end }}
 <p class="copyright">{{ .Site.Copyright | markdownify }}</p>
 <p class="advertisement">Powered by <a href="https://gohugo.io/">hugo</a> and <a href="https://github.com/joeroe/risotto">risotto</a>.</p>


### PR DESCRIPTION
…s #71

The `hugo.IsMultilingual` function
(https://gohugo.io/functions/hugo/ismultilingual/) can be used to test if there is more than one configured language. If not, we just skip including the language selection partial layout. It can mistakenly appear for mono-lingual sites/content because it is always included, and the `lang.html` partial layout seems to iterate through the entire range of configured languages, even when it's only one language.

Requires Hugo v0.124.0 or newer.