### PR TITLE
Add metadata (categories, tags, etc.) to content pages (see #79)

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,6 +2,11 @@
     <header class="content__header">
         <h1>{{ .Title | markdownify }}</h1>
     </header>
+
+    <div class="content__metadata">
+        {{ partial "metadata.html" . }}
+    </div>
+
     <div class="content__body">
         {{ .Content }}
     </div>

--- a/layouts/partials/metadata.html
+++ b/layouts/partials/metadata.html
@@ -1,0 +1,12 @@
+<p>
+{{ range $taxonomy, $terms := site.Taxonomies }}
+    {{ with $.GetTerms $taxonomy }}
+        {{ (site.GetPage $taxonomy).LinkTitle }}:
+        {{ range $k, $_ := . -}}
+            {{ if $k }}, {{ end }}
+            <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+        {{- end }}
+    <br>
+    {{ end }}
+{{ end }}
+</p>


### PR DESCRIPTION
Problem: tags, categories, and arbitrary taxonomies are not linked on content pages (#79). 

Solution: a metadata partial that lists all [taxonomies](https://gohugo.io/content-management/taxonomies/) and terms for any given content page. Works with default and user-defined taxonomies.

It's pretty simple:
1. the first `range` loop cycles through taxonomies
2. the `with` statement resets the context to each taxonomy map
3. the second `range` loop renders each term of the taxonomy

Hopefully this will allow for more flexible, user-defined organizational schema going forward. Cheers!