### PR TITLE
Only display lang footer if length of .Site.Languages > 1

### DIFF
--- a/layouts/partials/lang.html
+++ b/layouts/partials/lang.html
@@ -1,27 +1,29 @@
 <p>
-    {{ $siteLanguages := .Site.Languages }}
-    {{ $pageLang := .Page.Lang }}
-    
-    {{ $currentPage := . }}
-    {{ $pageName := "" }}
-    {{ range .Site.Menus.main }}
-      {{ if eq ($currentPage.Permalink) (.URL | absLangURL) }}
-        {{ $pageName = .Name }}
+    {{ if gt (len .Site.Languages) 1 }}
+      {{ $siteLanguages := .Site.Languages }}
+      {{ $pageLang := .Page.Lang }}
+      
+      {{ $currentPage := . }}
+      {{ $pageName := "" }}
+      {{ range .Site.Menus.main }}
+        {{ if eq ($currentPage.Permalink) (.URL | absLangURL) }}
+          {{ $pageName = .Name }}
+        {{ end }}
       {{ end }}
-    {{ end }}
-    
-    {{ range .Page.AllTranslations }}
-      {{ $translation := .}}
-      {{ range $siteLanguages }}
-          {{ if eq $translation.Lang .Lang }}
-            {{ $selected := false }}
-            {{ if eq $pageLang .Lang }}
-                <br/><span class="active">$ echo $LANG<br/><b>{{ .LanguageName }}</b></span><br/>
-
-            {{ else }}
-                <br/><a href="{{ $translation.Permalink }}">export LANG={{ .LanguageName }}; ./{{ $pageName }}</a><br/>
+      
+      {{ range .Page.AllTranslations }}
+        {{ $translation := .}}
+        {{ range $siteLanguages }}
+            {{ if eq $translation.Lang .Lang }}
+              {{ $selected := false }}
+              {{ if eq $pageLang .Lang }}
+                  <br/><span class="active">$ echo $LANG<br/><b>{{ .LanguageName }}</b></span><br/>
+  
+              {{ else }}
+                  <br/><a href="{{ $translation.Permalink }}">export LANG={{ .LanguageName }}; ./{{ $pageName }}</a><br/>
+              {{ end }}
             {{ end }}
-          {{ end }}
+        {{ end }}
       {{ end }}
     {{ end }}
 </p>


### PR DESCRIPTION
Fixes #71 - simply checks if `.Site.Languages` has more than one item.