### PR TITLE
Display taxonomies in sidebar

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -17,6 +17,16 @@
         </p>
     {{ end }}
 
+    {{ range $taxonomy, $terms := .Site.Taxonomies }}
+        {{ if (index $.Params $taxonomy) }}
+            <p>
+            {{ $taxonomy }}: 
+                {{ range $index, $term := (index $.Params $taxonomy) }}{{ if $index }}, {{ end }}
+                <a href="{{ printf "%s/" $taxonomy | relURL }}{{ $term | urlize }}">{{ $term }}</a>{{ end }}
+            </p>
+        {{ end }}
+    {{end}}
+
     {{ if and (.Params.toc) (.TableOfContents) }}
 	    <hr>
 	    On this page:

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -52,7 +52,6 @@
     position: sticky;
     top: 1rem;
     right: 1rem;
-    overflow-y: auto;
     max-height: 95vh;
 }
 


### PR DESCRIPTION
Fixes #79 

Displays taxonomies in sidebar like:
```html
            <p>
            categories: 
                <a href="[/categories/homelab](view-source:http://localhost:1313/categories/homelab)">homelab</a>
            </p>
            <p>
            tags: 
                <a href="[/tags/cybersecurity](view-source:http://localhost:1313/tags/cybersecurity)">cybersecurity</a>, 
                <a href="[/tags/hacking](view-source:http://localhost:1313/tags/hacking)">hacking</a>
            </p>