### PR TITLE
Fix twitter_simple shortcode error

### DIFF
--- a/exampleSite/content/post/rich-content.md
+++ b/exampleSite/content/post/rich-content.md
@@ -23,7 +23,7 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ## Twitter Simple Shortcode
 
-{{< twitter_simple 1085870671291310081 >}}
+{{< twitter_simple user="SanDiegoZoo" id="1453110110599868418">}}
 
 <br>
 


### PR DESCRIPTION
Hi, 

trying to build the exampleSite from this repository on a recent Hugo version (v0.140.2) results in an error message.

```
ERROR The "twitter_simple" shortcode requires two named parameters: user and id. See ".../risotto/exampleSite/content/post/rich-content.md:26:1"
```
Looking at https://gohugo.io/content-management/shortcodes/#twitter shows that the twitter shortcode requires user + id. Hence I created this PR that changes the twitter shortcode with the example from the Hugo Docs. After that, the blog compiles on Hugo v0.140.2