### PR TITLE
Fix deprecation warning regarding pagination

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -3,7 +3,6 @@ theme = "risotto"
 title = "risotto demo"
 author = "Joe Roe"
 copyright = "© [Joe Roe](https://joeroe.io) & [risotto contributors](https://github.com/joeroe/risotto/graphs/contributors)."
-paginate = 3
 languageCode = "en"
 DefaultContentLanguage = "en"
 enableInlineShortcodes = true
@@ -13,6 +12,9 @@ ignoreErrors = ["error-remote-getjson"]
 
 # Automatically add content sections to main menu
 sectionPagesMenu = "main"
+
+[pagination]
+pagerSize = 3
 
 [params]
 noindex = false


### PR DESCRIPTION
Building the exampleSite with Hugo v0.140.2 shows the following deprecation warning

```
ERROR deprecated: site config key paginate was deprecated in Hugo v0.128.0 and will be removed in Hugo 0.141.0. Use pagination.pagerSize instead.
```

This PR implements the fix from https://gohugo.io/templates/pagination/#configuration 