### PR TITLE
Update Twitter Shortcode

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -83,7 +83,7 @@ unsafe = true
     disabled = false
     simple = true
 
-  [privacy.twitter]
+  [privacy.x]
     disabled = false
     enableDNT = true
     simple = true
@@ -101,5 +101,5 @@ unsafe = true
   [services.instagram]
     disableInlineCSS = true
 
-  [services.twitter]
+  [services.x]
     disableInlineCSS = true

--- a/exampleSite/configTaxo.toml
+++ b/exampleSite/configTaxo.toml
@@ -12,7 +12,7 @@ series = "series"
     disabled = false
     simple = true
 
-  [privacy.twitter]
+  [privacy.x]
     disabled = false
     enableDNT = true
     simple = true

--- a/static/css/typography.css
+++ b/static/css/typography.css
@@ -136,7 +136,7 @@ blockquote::before {
     color: var(--muted);
 }
 
-.twitter-tweet::before {
+.x-tweet::before {
     content: "\f099";
     font-family: "Font Awesome 5 Brands";
     font-weight: 400;


### PR DESCRIPTION
Two instances of twitter shortcode + twitter in the CSS styling were changed to "x" in alignment with recent HUGO updates. Without this change HUGO throws errors.